### PR TITLE
add query and verbose_name

### DIFF
--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -308,6 +308,14 @@ class QuerySetSequence(ComparatorMixin):
         self._order_by = []
         self._standard_ordering = True
         self._low_mark, self._high_mark = 0, None
+        
+        # Query ( test case : admin model records )
+        self.model = args[0].model
+        self.query = args[0].query or sql.Query(self.model)
+
+        # verbose_name ( test case : admin delete )
+        self.verbose_name        = args[0].model._meta.verbose_name
+        self.verbose_name_plural = args[0].model._meta.verbose_name_plural
 
         self._iterable_class = QuerySequenceIterable
         self._result_cache = None

--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -7,6 +7,7 @@ import django
 from django.core.exceptions import (FieldError, MultipleObjectsReturned,
                                     ObjectDoesNotExist)
 from django.db import transaction
+from django.db.models import sql
 from django.db.models.base import Model
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.query import EmptyQuerySet, QuerySet


### PR DESCRIPTION
- I got an error in admin site about no query attribute in QuerySetSequence object
I added it from sql.Query(self.model)

- I got another error when I delete record about no verbose_name attribute in QuerySetSequence object
I add it from queryset.model.__meta.verbose_name 
( args[0].model._meta.verbose_name)

![123](https://user-images.githubusercontent.com/50912478/80160470-0614b900-85ce-11ea-98a6-e0b2306abe89.PNG)


```
def get_queryset(self):
        db_list = Databases.objects.all().filter(model_name=self.model._meta.model_name).exclude(count=0)
        if db_list.count() != 0:           
            return reduce(QuerySetSequence, [super(CustomModelManager, self).get_queryset().using(db.get_name) for db in db_list])           
        return super(CustomModelManager, self).get_queryset().none()
```

