### PR TITLE
Add support for values()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Changelog
 next
 ====
 
+* [Enhancement] Support the ``values()`` method.
+
 0.13 (2020-07-27)
 =================
 

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ multiple ``QuerySets``:
       -
     * - |values|_
       - |check|
-      -
+      - See [1]_ for information on including the ``QuerySet`` index: ``'#'``.
     * - |values_list|_
       - |xmark|
       -
@@ -318,7 +318,8 @@ multiple ``QuerySets``:
 .. [1]  ``QuerySetSequence`` supports a special field lookup that looks up the
         index of the ``QuerySet``, this is represented by ``'#'``. This can be
         used in any of the operations that normally take field lookups (i.e.
-        ``filter()``, ``exclude()``, and ``get()``), as well as ``order_by()``.
+        ``filter()``, ``exclude()``, and ``get()``), as well as ``order_by()``
+        and ``values()``.
 
         A few examples are below:
 

--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ multiple ``QuerySets``:
       - |xmark|
       -
     * - |values|_
-      - |xmark|
+      - |check|
       -
     * - |values_list|_
       - |xmark|

--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -39,7 +39,16 @@ def cumsum(seq):
         yield s
 
 
-class ComparatorMixin:
+class QuerySequenceIterable:
+    def __init__(self, querysetsequence):
+        # Create a clone so that subsequent calls to iterate are kept separate.
+        self._querysets = querysetsequence._querysets
+        self._queryset_idxs = querysetsequence._queryset_idxs
+        self._order_by = querysetsequence._order_by
+        self._standard_ordering = querysetsequence._standard_ordering
+        self._low_mark = querysetsequence._low_mark
+        self._high_mark = querysetsequence._high_mark
+
     @classmethod
     def _get_field_names(cls, model):
         """Return a list of field names that are part of a model."""
@@ -122,17 +131,6 @@ class ComparatorMixin:
                 return 0
 
         return comparator
-
-
-class QuerySequenceIterable(ComparatorMixin):
-    def __init__(self, querysetsequence):
-        # Create a clone so that subsequent calls to iterate are kept separate.
-        self._querysets = querysetsequence._querysets
-        self._queryset_idxs = querysetsequence._queryset_idxs
-        self._order_by = querysetsequence._order_by
-        self._standard_ordering = querysetsequence._standard_ordering
-        self._low_mark = querysetsequence._low_mark
-        self._high_mark = querysetsequence._high_mark
 
     def _ordered_iterator(self):
         """
@@ -295,7 +293,7 @@ class QuerySequenceIterable(ComparatorMixin):
         return self._unordered_iterator()
 
 
-class QuerySetSequence(ComparatorMixin):
+class QuerySetSequence:
     """
     Wrapper for multiple QuerySets without the restriction on the identity of
     the base models.
@@ -721,7 +719,7 @@ class QuerySetSequence(ComparatorMixin):
 
     def _get_first_or_last(self, items, order_fields, reverse):
         # Generate a comparator and sort the items.
-        comparator = self._generate_comparator(order_fields)
+        comparator = self._iterable_class._generate_comparator(order_fields)
         items = sorted(items, key=functools.cmp_to_key(comparator), reverse=reverse)
 
         # Return the first one (whether this is first or last is controlled by

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -1,5 +1,5 @@
 from datetime import date
-from unittest import skip, skipIf
+from unittest import skip
 from unittest.mock import patch
 
 import django
@@ -1530,10 +1530,6 @@ class TestNotImplemented(TestCase):
     def test_distinct(self):
         with self.assertRaises(NotImplementedError):
             self.all.distinct()
-
-    def test_values(self):
-        with self.assertRaises(NotImplementedError):
-            self.all.values()
 
     def test_values_list(self):
         with self.assertRaises(NotImplementedError):

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -986,7 +986,7 @@ class TestOrderBy(TestBase):
             qss = self.all.order_by('#', 'title')
 
         # Ensure that _ordered_iterator isn't called.
-        with patch('queryset_sequence.QuerySequenceIterable._ordered_iterator',
+        with patch('queryset_sequence.BaseIterable._ordered_iterator',
                    side_effect=AssertionError('_ordered_iterator should not be called')):
             # Check the titles are properly ordered.
             data = [it.title for it in qss]
@@ -1014,7 +1014,7 @@ class TestOrderBy(TestBase):
             qss = self.all.order_by('-#', 'title')
 
         # Ensure that _ordered_iterator isn't called.
-        with patch('queryset_sequence.QuerySequenceIterable._ordered_iterator',
+        with patch('queryset_sequence.BaseIterable._ordered_iterator',
                    side_effect=AssertionError('_ordered_iterator should not be called')):
             # Check the titles are properly ordered.
             data = [it.title for it in qss]

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -11,6 +11,7 @@ class TestValues(TestBase):
         authors = [it['author_id'] for it in values]
         self.assertEqual(titles, self.TITLES_BY_PK)
         self.assertEqual(authors, [2, 2, 1, 1, 2])
+        self.assertCountEqual(values[0].keys(), ['#', 'id', 'author_id', 'pages', 'publisher_id', 'release', 'title'])
 
     def test_fields(self):
         """Ensure the proper fields are returned."""
@@ -19,17 +20,24 @@ class TestValues(TestBase):
             # logic this converts the entire results to a list before getting
             # the first element.
             data = list(self.all.values('title'))[0]
-        self.assertEqual(data, {'#': 0, 'title': 'Fiction'})
+        self.assertEqual(data, {'title': 'Fiction'})
 
     def test_foreign_key(self):
         """Calling values for a foreign key should end up with the ID."""
         with self.assertNumQueries(2):
             data = list(self.all.values('author'))[0]
-        self.assertEqual(data, {'#': 0, 'author': 2})
+        self.assertEqual(data, {'author': 2})
 
     def test_join(self):
+        """Including a field across a foreign key join should work."""
         with self.assertNumQueries(2):
             data = list(self.all.values('author__name'))[0]
+        self.assertEqual(data, {'author__name': 'Bob'})
+
+    def test_qss_field(self):
+        """Should be able to include the ordering of the QuerySet in the returned fields."""
+        with self.assertNumQueries(2):
+            data = list(self.all.values('#', 'author__name'))[0]
         self.assertEqual(data, {'#': 0, 'author__name': 'Bob'})
 
     def test_order_by(self):
@@ -54,4 +62,4 @@ class TestValues(TestBase):
         ])
 
         # Check that only the requested fields are returned.
-        self.assertEqual(values[0], {'#': 1, 'title': 'Some Article'})
+        self.assertEqual(values[0], {'title': 'Some Article'})

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -1,0 +1,57 @@
+from tests.test_querysetsequence import TestBase
+
+
+class TestValues(TestBase):
+    def test_values(self):
+        """Ensure the values conversion works as expected."""
+        with self.assertNumQueries(2):
+            values = list(self.all.values())
+        titles = [it['title'] for it in values]
+        # Foreign keys are kept as IDs.
+        authors = [it['author_id'] for it in values]
+        self.assertEqual(titles, self.TITLES_BY_PK)
+        self.assertEqual(authors, [2, 2, 1, 1, 2])
+
+    def test_fields(self):
+        """Ensure the proper fields are returned."""
+        with self.assertNumQueries(2):
+            # Note that to ensure we go through most of the QuerySetSequence
+            # logic this converts the entire results to a list before getting
+            # the first element.
+            data = list(self.all.values('title'))[0]
+        self.assertEqual(data, {'#': 0, 'title': 'Fiction'})
+
+    def test_foreign_key(self):
+        """Calling values for a foreign key should end up with the ID."""
+        with self.assertNumQueries(2):
+            data = list(self.all.values('author'))[0]
+        self.assertEqual(data, {'#': 0, 'author': 2})
+
+    def test_join(self):
+        with self.assertNumQueries(2):
+            data = list(self.all.values('author__name'))[0]
+        self.assertEqual(data, {'#': 0, 'author__name': 'Bob'})
+
+    def test_order_by(self):
+        """Ensure that order_by() propagates to QuerySets and iteration."""
+        # Check the titles are properly ordered.
+        with self.assertNumQueries(2):
+            data = [it['title'] for it in self.all.values('title').order_by('title')]
+        self.assertEqual(data, sorted(self.TITLES_BY_PK))
+
+    def test_order_by_other_field(self):
+        """Ordering by a field that isn't included in the responses should work."""
+        with self.assertNumQueries(2):
+            values = list(self.all.values('title').order_by('release'))
+        data = [it['title'] for it in values]
+        # Check the expected ordering.
+        self.assertEqual(data, [
+            'Some Article',
+            'Django Rocks',
+            'Alice in Django-land',
+            'Fiction',
+            'Biography',
+        ])
+
+        # Check that only the requested fields are returned.
+        self.assertEqual(values[0], {'#': 1, 'title': 'Some Article'})


### PR DESCRIPTION
This adds support for calling `values()` on a `QuerySetSequence`. The index of the `QuerySet` can be included in the response by specifying `'#'` as one of the fields to return.