### PR TITLE
Bump supported Django REST Framework to 3.12.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ next
 ====
 
 * [Enhancement] Support the ``values()`` and ``values_list()`` methods.
+* Officially support Django REST Framework 3.12.
 
 0.13 (2020-07-27)
 =================

--- a/tox.ini
+++ b/tox.ini
@@ -11,9 +11,9 @@ envlist =
     # Without Django REST Framework.
     py{36,37,38}-django{22,30,31,master},
     # Django REST Framework 3.9.2 added support for Django 2.2.
-    py{36,37,38}-django22-drf{39,310,311,master},
+    py{36,37,38}-django22-drf{39,310,311,312,master},
     # Django REST Framework 3.11 added support for Django 3.0.
-    py{36,37,38}-django{30,31,master}-drf{311,master}
+    py{36,37,38}-django{30,31,master}-drf{311,312,master}
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Doesn't seem to have any breaking changes: https://www.django-rest-framework.org/community/3.12-announcement/