### PR TITLE
Support filter(*args)

### DIFF
--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -685,12 +685,12 @@ class QuerySetSequence:
         self._querysets = [self._querysets[i] for i in self._queryset_idxs]
 
     # Methods that return new QuerySets
-    def filter(self, **kwargs):
+    def filter(self, *args, **kwargs):
         qss_fields, fields = self._separate_filter_fields(**kwargs)
 
         clone = self._clone()
         clone._filter_or_exclude_querysets(False, **qss_fields)
-        clone._querysets = [qs.filter(**fields) for qs in clone._querysets]
+        clone._querysets = [qs.filter(*args, **fields) for qs in clone._querysets]
         return clone
 
     def exclude(self, **kwargs):

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -8,7 +8,7 @@ from django.core.exceptions import (FieldDoesNotExist,
                                     FieldError,
                                     MultipleObjectsReturned,
                                     ObjectDoesNotExist)
-from django.db.models import Count
+from django.db.models import Count, Q
 from django.db.models.query import EmptyQuerySet
 from django.test import TestCase
 
@@ -440,6 +440,17 @@ class TestFilter(TestBase):
         # Filter to just Bob's work.
         with self.assertNumQueries(0):
             bob_qss = self.all.filter(author__name=self.bob.name)
+        with self.assertNumQueries(2):
+            self.assertEqual(bob_qss.count(), 3)
+
+    def test_filter_args(self):
+        """
+        Ensure that filter() properly filters the children QuerySets, even when
+        being passed args.
+        """
+        # Filter to just Bob's work.
+        with self.assertNumQueries(0):
+            bob_qss = self.all.filter(Q(author=self.bob))
         with self.assertNumQueries(2):
             self.assertEqual(bob_qss.count(), 3)
 


### PR DESCRIPTION
Hi Patrick,

Some user contributed query building code [similar to what django.contrib.admin does for search_fields](https://github.com/yourlabs/django-autocomplete-light/pull/1169).

This broke QSS support for two reasons:

- it combines `Q` objects with `|` and then calls qss.filter(built_filter)
- because of that, there is also code to detect if one of the filter is on an M2M table in which case it knowns it needs to call distinct

What do you think of this proposal ? We have a patch [ready in DAL](https://github.com/yourlabs/django-autocomplete-light/pull/1199) and I can still do any changes to fit the design decisions that you may want to make.

Thank you for your feedback