### PR TITLE
Implement distinct()

### DIFF
--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -724,6 +724,8 @@ class QuerySetSequence:
         return clone
 
     def distinct(self, *fields):
+        if len({qs.model for qs in self._querysets}) != len(self._querysets):
+            raise NotImplementedError('Multiple QS of same model unsupported')
         clone = self._clone()
         clone._querysets = [qs.distinct() for qs in clone._querysets]
         return clone

--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -724,7 +724,9 @@ class QuerySetSequence:
         return clone
 
     def distinct(self, *fields):
-        raise NotImplementedError()
+        clone = self._clone()
+        clone._querysets = [qs.distinct() for qs in clone._querysets]
+        return clone
 
     def values(self, *fields, **expressions):
         _, std_fields = self._separate_fields(*fields)

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -428,6 +428,11 @@ class TestDistinct(TestBase):
         for qs in distinct._querysets:
             assert qs.query.distinct
 
+    def test_multiple_querysets_same_model(self):
+        qss = QuerySetSequence(Book.objects.all(), Book.objects.all())
+        with self.assertRaises(NotImplementedError):
+            qss.distinct()
+
 
 class TestFilter(TestBase):
     def test_filter(self):

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -419,6 +419,16 @@ class TestUsing(TestBase):
         self.assertEqual(titles, self.TITLES_BY_PK)
 
 
+class TestDistinct(TestBase):
+    def test_distinct(self):
+        for qs in self.all._querysets:
+            assert not qs.query.distinct
+        with self.assertNumQueries(0):
+            distinct = self.all.distinct()
+        for qs in distinct._querysets:
+            assert qs.query.distinct
+
+
 class TestFilter(TestBase):
     def test_filter(self):
         """
@@ -1537,10 +1547,6 @@ class TestNotImplemented(TestCase):
     """The following methods have not been implemented in QuerySetSequence."""
     def setUp(self):
         self.all = QuerySetSequence()
-
-    def test_distinct(self):
-        with self.assertRaises(NotImplementedError):
-            self.all.distinct()
 
     def test_dates(self):
         with self.assertRaises(NotImplementedError):


### PR DESCRIPTION
This implementation of distinct() is simple and natural: call distinct() on all QuerySets of a QuerySetSequence.