### PR TITLE
Avoid a warning on Django >= 3.2.

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -34,3 +34,6 @@ INSTALLED_APPS = (
 AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',
 )
+
+# Avoid a warning on Django >= 3.2.
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@
 # versions.
 envlist =
     # Without Django REST Framework.
-    py{36,37,38,39}-django{22,30,31,master},
+    py{36,37,38,39}-django{22,30,31,32,master},
     # Django REST Framework 3.9.2 added support for Django 2.2.
     py{36,37,38,39}-django22-drf{39,310,311,312,master},
     # Django REST Framework 3.11 added support for Django 3.0.


### PR DESCRIPTION
See https://docs.djangoproject.com/en/dev/releases/3.2/#customizing-type-of-auto-created-primary-keys