### PR TITLE
Drop support for Python 3.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,8 @@ next
 Features
 --------
 
-* Support Django 3.2 (`#78 <https://github.com/clokep/django-querysetsequence/pull/78>`_)
+* Support Django 3.2 (`#78 <https://github.com/clokep/django-querysetsequence/pull/78>`_,
+  `#81 <https://github.com/clokep/django-querysetsequence/pull/81>`_)
 * Support Python 3.9. (`#78 <https://github.com/clokep/django-querysetsequence/pull/78>`_)
 * Support the ``values()`` and ``values_list()`` methods.
   (`#73 <https://github.com/clokep/django-querysetsequence/pull/73>`_,
@@ -36,6 +37,7 @@ Miscellaneous
   (`#72 <https://github.com/clokep/django-querysetsequence/pull/72>`_)
 * Support Django REST Framework 3.12. (`#75 <https://github.com/clokep/django-querysetsequence/pull/75>`_)
 * Switch continuous integration to GitHub Actions. (`#79 <https://github.com/clokep/django-querysetsequence/pull/79>`_)
+* Drop support for Python 3.5. (`#82 <https://github.com/clokep/django-querysetsequence/pull/82>`_)
 
 
 0.13 (2020-07-27)

--- a/setup.py
+++ b/setup.py
@@ -31,19 +31,14 @@ setup(
         'Framework :: Django :: 3.0',
         'Framework :: Django :: 3.1',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'License :: OSI Approved :: ISC License (ISCL)',
     ],
     install_requires=[
         'django>=2.2',
     ],
-    extras_require={
-        'dev': [
-            'mock',
-        ],
-    },
     python_requires=">=3.5",
 )

--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,5 @@ setup(
     install_requires=[
         'django>=2.2',
     ],
-    python_requires=">=3.5",
+    python_requires=">=3.6",
 )


### PR DESCRIPTION
This was already dropped in CI, but now require Python 3.6+.