### PR TITLE
Add support for `contains()`.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Features
 --------
 
 * Support Django 4.0. (`#83 <https://github.com/clokep/django-querysetsequence/pull/83>`_)
+* Support the ``contains()`` method. (`#85 <https://github.com/clokep/django-querysetsequence/pull/85>`_)
 
 Miscellaneous
 -------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -170,6 +170,9 @@ Summary of Supported APIs
     * - |exists|_
       - |check|
       -
+    * - |contains|_
+      - |check|
+      -
     * - |update|_
       - |check|
       -
@@ -281,6 +284,8 @@ Summary of Supported APIs
 .. _aggregate: https://docs.djangoproject.com/en/dev/ref/models/querysets/#aggregate
 .. |exists| replace:: ``exists()``
 .. _exists: https://docs.djangoproject.com/en/dev/ref/models/querysets/#exists
+.. |contains| replace:: ``contains()``
+.. _contains: https://docs.djangoproject.com/en/dev/ref/models/querysets/#contains
 .. |update| replace:: ``update()``
 .. _update: https://docs.djangoproject.com/en/dev/ref/models/querysets/#update
 .. |delete| replace:: ``delete()``

--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -982,6 +982,9 @@ class QuerySetSequence:
     def exists(self):
         return any(qs.exists() for qs in self._querysets)
 
+    def contains(self, obj):
+        return any(qs.contains(obj) for qs in self._querysets)
+
     def update(self, **kwargs):
         with transaction.atomic():
             return sum(qs.update(**kwargs) for qs in self._querysets)


### PR DESCRIPTION
Django 4.0 added support for the [`contains()` method](https://docs.djangoproject.com/en/dev/ref/models/querysets/#contains) a more optimized version of using `in`.