### PR TITLE
Proxy query attribute.

### DIFF
--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -1018,6 +1018,21 @@ class QuerySetSequence:
         """
         return bool(self._order_by)
 
+    @property
+    def query(self):
+        """
+        Proxy query attribute.
+
+        This attribute is used to provide a `.query` interface used by some of
+        django admin views.
+        """
+        # The easiest way to create an empty object with arbitrary attributes.
+        query = lambda: None
+        query.order_by = self._order_by
+        query.select_related = self.select_related
+        query.prefetch_related = self.prefetch_related
+        return query
+
     # Methods specific to QuerySetSequence.
     def get_querysets(self):
         """Returns a list of the QuerySet objects which form the sequence."""


### PR DESCRIPTION
Hi @clokep ,

Please, take a look at this PR. 
I saw issues with Django admin (for example https://github.com/clokep/django-querysetsequence/issues/65) and with other packages using **querysetsequence** . All these issues have pattern: `'QuerySetSequence' object has no attribute 'query'`.
This PR should fix it and shouldn't break anything.

Please, let me know wdyt 🙏 