### PR TITLE
Drop support for old versions of Django / DRF, support Django 4.1.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,15 @@
 Changelog
 #########
 
+next
+====
+
+Maintenance
+-----------
+
+* Drop support for Django 2.2 and 3.1. (`#98 <https://github.com/clokep/django-querysetsequence/pull/98>`_)
+* Drop support for Django REST Framework < 3.11. (`#98 <https://github.com/clokep/django-querysetsequence/pull/98>`_)
+
 0.16 (2022-04-01)
 =================
 

--- a/README.rst
+++ b/README.rst
@@ -75,8 +75,8 @@ Project Information
 
 django-querysetsequence is released under the ISC license, its documentation lives
 on `Read the Docs`_, the code on `GitHub`_, and the latest release on `PyPI`_. It
-supports Python 3.7+, Django 2.2/3.1/3.2/4.0, and is optionally compatible with
-`Django REST Framework`_ 3.9+.
+supports Python 3.7+, Django 3.2/4.0/4.1, and is optionally compatible with
+`Django REST Framework`_ 3.11+.
 
 .. _Read the Docs: https://django-querysetsequence.readthedocs.io/
 .. _GitHub: https://github.com/clokep/django-querysetsequence

--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -843,16 +843,8 @@ class QuerySetSequence:
     def dates(self, field, kind, order="ASC"):
         raise NotImplementedError()
 
-    # Django 3.1 added an additional parameter.
-    if django.VERSION < (3, 1):
-
-        def datetimes(self, field_name, kind, order="ASC", tzinfo=None):
-            raise NotImplementedError()
-
-    else:
-
-        def datetimes(self, field_name, kind, order="ASC", tzinfo=None, is_dst=None):
-            raise NotImplementedError()
+    def datetimes(self, field_name, kind, order="ASC", tzinfo=None, is_dst=None):
+        raise NotImplementedError()
 
     def none(self):
         # This is a bit odd, but use the first QuerySet to properly return an

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,10 +16,9 @@ classifiers =
     Environment :: Web Environment
     Topic :: Internet
     Framework :: Django
-    Framework :: Django :: 2.2
-    Framework :: Django :: 3.1
     Framework :: Django :: 3.2
     Framework :: Django :: 4.0
+    Framework :: Django :: 4.1
     Programming Language :: Python
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -36,7 +35,7 @@ project_urls =
 [options]
 packages =
     queryset_sequence
-install_requires = django>=2.2
+install_requires = django>=3.2
 python_requires = >=3.7
 
 [flake8]

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -945,10 +945,7 @@ class TestOrderBy(TestBase):
         """Ordering by a non-existent field raises an exception upon evaluation."""
         with self.assertRaises(FieldError):
             with self.assertNumQueries(0):
-                qss = self.all.order_by("pages")
-            # Note that starting in Django 3.1 the exception is raised when the
-            # QuerySet is created, not when it is evaluated.
-            list(qss)
+                self.all.order_by("pages")
 
     def test_order_by_multi(self):
         """Test ordering by multiple fields."""

--- a/tox.ini
+++ b/tox.ini
@@ -9,18 +9,13 @@
 # versions.
 envlist =
     # Without Django REST Framework.
-    py{37,38,39}-django{22,31,32},
-    # Django 3.2.9 added support for Python 3.10.
-    py310-django32,
-    # Django REST Framework 3.9.2 added support for Django 2.2.
-    py{37,38,39}-django22-drf{39,310,311,312,313,master},
+    py{37,38,39,310}-django32,
     # Django REST Framework 3.11 added support for Django 3.0.
-    py{37,38,39}-django{31,32}-drf{311,312,313,master},
-    py310-django32-drf{311,312,master},
+    py{37,38,39,310}-django32-drf{311,312,313,master},
     # Django 4.0 drops support for Python 3.7.
-    py{38,39,310}-django{40,main},
+    py{38,39,310}-django{40,41,main},
     # Django REST Framework 3.13 added support for Django 4.0.
-    py{38,39,310}-django{40,main}-drf{313,master}
+    py{38,39,310}-django{40,41,main}-drf{313,master}
 isolated_build = True
 skip_missing_interpreters = True
 
@@ -31,13 +26,10 @@ commands =
     coverage html
 deps =
     coverage
-    django22: Django>=2.2,<3.0
-    django31: Django>=3.1,<3.2
     django32: Django>=3.2,<3.3
     django40: Django>=4.0,<4.1
+    django41: Django>=4.1,<4.2
     djangomain: https://codeload.github.com/django/django/zip/main
-    drf39: djangorestframework>=3.9.2,<3.10
-    drf310: djangorestframework>=3.10,<3.11
     drf311: djangorestframework>=3.11,<3.12
     drf312: djangorestframework>=3.12,<3.13
     drf313: djangorestframework>=3.13,<3.14


### PR DESCRIPTION
Django 2.2 and 3.1 are no longer supported. Drops versions of django-rest-framework that didn't support at least Django 3.2.

Adds (basic) support for Django 4.1.