### PR TITLE
Support Django 5.0, and 5.1; Python 3.12.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,19 @@
 Changelog
 #########
 
+next
+====
+
+Maintenance
+-----------
+
+* Support Python 3.12. (`#106 <https://github.com/clokep/django-querysetsequence/pull/106>`_)
+* Support Django 5.0, 5.1, and 5.2. (`#106 <https://github.com/clokep/django-querysetsequence/pull/106>`_)
+* Support Django REST Framework 3.15. (`#106 <https://github.com/clokep/django-querysetsequence/pull/106>`_)
+* Drop support for Django 3.2, 4.0, and 4.1. (`#106 <https://github.com/clokep/django-querysetsequence/pull/106>`_)
+* Drop support for Django REST Framework 3.11, 3.12 and 3.13. (`#106 <https://github.com/clokep/django-querysetsequence/pull/106>`_)
+
+
 0.17 (2023-06-27)
 =================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Maintenance
 -----------
 
 * Support Python 3.12. (`#106 <https://github.com/clokep/django-querysetsequence/pull/106>`_)
-* Support Django 5.0, 5.1, and 5.2. (`#106 <https://github.com/clokep/django-querysetsequence/pull/106>`_)
+* Support Django 5.0 and 5.1. (`#106 <https://github.com/clokep/django-querysetsequence/pull/106>`_)
 * Support Django REST Framework 3.15. (`#106 <https://github.com/clokep/django-querysetsequence/pull/106>`_)
 * Drop support for Django 3.2, 4.0, and 4.1. (`#106 <https://github.com/clokep/django-querysetsequence/pull/106>`_)
 * Drop support for Django REST Framework 3.11, 3.12 and 3.13. (`#106 <https://github.com/clokep/django-querysetsequence/pull/106>`_)

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ envlist =
     # Django REST Framework 3.14 added support for Django 4.1.
     py{38,39,310,311}-django42-drf314,
     # Django REST Framework 3.15 added support for Django 5.0 and Python 3.12.
-    py{38,39,310,311,312}-django{42,50,51,main}-drf{315,master},
+    py{310,311,312}-django{42,50,51,main}-drf{315,master},
     # Only run a subset against postgres.
     py310-django{42,51}-drf315-postgres
 isolated_build = True

--- a/tox.ini
+++ b/tox.ini
@@ -11,15 +11,15 @@ envlist =
     # Without Django REST Framework.
     py{38,39,310,311,312}-django42,
     # Django 5.0 drops support for Python < 3.10.
-    py{310,311,312}-django{50,51,52,main},
-    # Django 5.2 adds support for Python 3.13.
-    py313-django{52,main},
+    py{310,311}-django{50,51,main},
+    # Django 5.1 adds support for Python 3.13.
+    py313-django{51,main},
     # Django REST Framework 3.14 added support for Django 4.1.
     py{38,39,310,311}-django42-drf314,
     # Django REST Framework 3.15 added support for Django 5.0 and Python 3.12.
-    py{38,39,310,311,312}-django{42,50,51,52,main}-drf{315,master},
+    py{38,39,310,311,312}-django{42,50,51,main}-drf{315,master},
     # Only run a subset against postgres.
-    py310-django{42,52}-drf315-postgres
+    py310-django{42,51}-drf315-postgres
 isolated_build = True
 skip_missing_interpreters = True
 
@@ -32,8 +32,7 @@ deps =
     coverage
     django42: Django>=4.2,<4.3
     django50: Django>=5.0,<5.1
-    django51: Django>=5.1,<5.2
-    django52: Django>=5.2b1,<5.3
+    django51: Django>=5.1b1,<5.2
     djangomain: https://codeload.github.com/django/django/zip/main
     drf314: djangorestframework>=3.14,<3.15
     drf315: djangorestframework>=3.15,<3.16

--- a/tox.ini
+++ b/tox.ini
@@ -9,17 +9,17 @@
 # versions.
 envlist =
     # Without Django REST Framework.
-    py{38,39,310}-django{32,40,41,42,main},
-    # Django REST Framework 3.11 added support for Django 3.0.
-    py{38,39,310}-django32-drf{311,312,313,314,master},
-    # Django REST Framework 3.13 added support for Django 4.0.
-    py{38,39,310}-django{40,41,42,main}-drf313,
-    # Django 4.1 adds support for Python 3.11.
-    py311-django{41,42},
+    py{38,39,310,311,312}-django42,
+    # Django 5.0 drops support for Python < 3.10.
+    py{310,311,312}-django{50,51,52,main},
+    # Django 5.2 adds support for Python 3.13.
+    py313-django{52,main},
     # Django REST Framework 3.14 added support for Django 4.1.
-    py311-django{41,42,main}-drf{314,master},
+    py{38,39,310,311}-django42-drf314,
+    # Django REST Framework 3.15 added support for Django 5.0 and Python 3.12.
+    py{38,39,310,311,312}-django{42,50,51,52,main}-drf{315,master},
     # Only run a subset against postgres.
-    py310-django{41,42}-drf313-postgres
+    py310-django{42,52}-drf315-postgres
 isolated_build = True
 skip_missing_interpreters = True
 
@@ -30,15 +30,13 @@ commands =
     coverage html
 deps =
     coverage
-    django32: Django>=3.2,<3.3
-    django40: Django>=4.0,<4.1
-    django41: Django>=4.1,<4.2
     django42: Django>=4.2,<4.3
+    django50: Django>=5.0,<5.1
+    django51: Django>=5.1,<5.2
+    django52: Django>=5.2b1,<5.3
     djangomain: https://codeload.github.com/django/django/zip/main
-    drf311: djangorestframework>=3.11,<3.12
-    drf312: djangorestframework>=3.12,<3.13
-    drf313: djangorestframework>=3.13,<3.14
     drf314: djangorestframework>=3.14,<3.15
+    drf315: djangorestframework>=3.15,<3.16
     drfmaster: https://codeload.github.com/encode/django-rest-framework/zip/master
     postgres: psycopg2
 setenv =


### PR DESCRIPTION
Also drops support for Django 3.2, 4.0, 4.1; django-rest-framework 3.11, 3.12, 3.13.