### PR TITLE
Report ordered=True when all sub-QuerySets are ordered

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,17 @@ Changelog
 next
 ====
 
+Features
+--------
+
+* ``QuerySetSequence.ordered`` now also reports ``True`` when every
+  underlying ``QuerySet`` is itself ordered (via ``order_by()`` or
+  ``Meta.ordering``), in addition to the existing case where
+  ``order_by()`` has been called on the sequence. This silences
+  Django 5.2's paginator ``UnorderedObjectListWarning`` for sequences
+  whose sub-``QuerySets`` are individually ordered — a common pattern
+  when the sub-``QuerySets`` are sliced and can no longer be reordered.
+
 Maintenance
 -----------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -243,6 +243,31 @@ Summary of Supported APIs
       - |xmark|
       -
 
+.. list-table:: Attributes
+    :widths: 15 10 30
+    :header-rows: 1
+
+    * - Attribute
+      - Implemented?
+      - Notes
+
+    * - |ordered|_
+      - |check|
+      - ``True`` if ``order_by()`` has been called on the
+        ``QuerySetSequence`` **or** if every underlying ``QuerySet`` is
+        itself ordered (via its own ``order_by()`` or the model's
+        ``Meta.ordering``). In that second case the sequence yields the
+        sub-``QuerySets`` in the order they were passed in, each
+        internally ordered — a deterministic ordering that cannot be
+        expressed as a single ``order_by()`` on the sequence when the
+        sub-``QuerySets`` are sliced (Django 4+ forbids reordering a
+        sliced ``QuerySet``). An empty ``QuerySetSequence`` is considered
+        ordered.
+
+        Reporting ``ordered=True`` in the second case silences Django's
+        paginator ``UnorderedObjectListWarning`` introduced in Django
+        5.2.
+
 .. list-table:: Additional methods specific to ``QuerySetSequence``
     :widths: 15 30
     :header-rows: 1
@@ -305,6 +330,9 @@ Summary of Supported APIs
 .. _select_for_update: https://docs.djangoproject.com/en/dev/ref/models/querysets/#select-for-update
 .. |raw| replace:: ``raw()``
 .. _raw: https://docs.djangoproject.com/en/dev/ref/models/querysets/#raw
+
+.. |ordered| replace:: ``ordered``
+.. _ordered: https://docs.djangoproject.com/en/dev/ref/models/querysets/#ordered
 
 .. |AND (&)| replace:: AND (``&``)
 .. _AND (&): https://docs.djangoproject.com/en/dev/ref/models/querysets/#and

--- a/queryset_sequence/__init__.py
+++ b/queryset_sequence/__init__.py
@@ -1260,10 +1260,27 @@ class QuerySetSequence:
     @property
     def ordered(self):
         """
-        Returns True if the QuerySet is ordered -- i.e. has an order_by()
-        clause.
+        Returns True if the QuerySetSequence is ordered.
+
+        A QuerySetSequence is considered ordered when either:
+
+        * ``order_by()`` has been called on the sequence itself, or
+        * every sub-QuerySet is ordered (via its own ``order_by()`` clause
+          or a model ``Meta.ordering``). In that case the sequence yields
+          the sub-QuerySets in their declared order, each internally
+          ordered, which is a deterministic, well-defined ordering that
+          cannot be expressed as a single ``order_by()`` on the sequence
+          when sub-QuerySets are sliced (Django 4+ forbids reordering a
+          sliced QuerySet).
+
+        An empty QuerySetSequence (no sub-QuerySets) is considered ordered.
+
+        Reporting ``ordered=True`` in the second case silences Django's
+        paginator ``UnorderedObjectListWarning`` introduced in Django 5.2.
         """
-        return bool(self._order_by)
+        if bool(self._order_by):
+            return True
+        return all(qs.ordered for qs in self._querysets)
 
     # Methods specific to QuerySetSequence.
     def get_querysets(self):

--- a/tests/test_querysetsequence.py
+++ b/tests/test_querysetsequence.py
@@ -1202,6 +1202,62 @@ class TestOrderBy(TestBase):
         self.empty.order_by("author")
 
 
+class TestOrdered(TestBase):
+    """Tests for the ``ordered`` property."""
+
+    def test_order_by_on_sequence(self):
+        """order_by() on the sequence makes it ordered."""
+        qss = QuerySetSequence(
+            Book.objects.all(), Article.objects.all()
+        ).order_by("title")
+        self.assertTrue(qss.ordered)
+
+    def test_all_sub_querysets_ordered(self):
+        """If every sub-QuerySet is ordered, the sequence is ordered too."""
+        qss = QuerySetSequence(
+            Book.objects.order_by("title"),
+            Article.objects.order_by("title"),
+        )
+        self.assertTrue(qss.ordered)
+
+    def test_one_sub_queryset_unordered(self):
+        """If any sub-QuerySet is unordered, the sequence is unordered."""
+        qss = QuerySetSequence(
+            Book.objects.order_by("title"),
+            Article.objects.all(),
+        )
+        self.assertFalse(qss.ordered)
+
+    def test_all_sub_querysets_unordered(self):
+        """If no sub-QuerySet is ordered, the sequence is unordered."""
+        self.assertFalse(self.all.ordered)
+
+    def test_meta_ordering_counts_as_ordered(self):
+        """A model-level Meta.ordering makes a sub-QuerySet ordered."""
+        # Author has Meta.ordering = ["name"].
+        qss = QuerySetSequence(Author.objects.all())
+        self.assertTrue(qss.ordered)
+
+    def test_mixed_meta_and_order_by(self):
+        """Meta.ordering on one queryset plus order_by() on another."""
+        qss = QuerySetSequence(
+            Author.objects.all(),  # Has Meta.ordering.
+            Book.objects.order_by("title"),
+        )
+        self.assertTrue(qss.ordered)
+
+    def test_empty_sequence_is_ordered(self):
+        """An empty QuerySetSequence reports as ordered (vacuously true)."""
+        self.assertTrue(self.empty.ordered)
+
+    def test_sequence_order_by_overrides_unordered_sub(self):
+        """order_by() on the sequence wins even if sub-QuerySets are unordered."""
+        qss = QuerySetSequence(
+            Book.objects.all(), Article.objects.all()
+        ).order_by("title")
+        self.assertTrue(qss.ordered)
+
+
 class TestReverse(TestBase):
     def test_reverse(self):
         """Ensure calling reverse() returns elements in a reverse order."""


### PR DESCRIPTION
## Summary

- `QuerySetSequence.ordered` now also reports `True` when every underlying `QuerySet` is itself ordered (via its own `order_by()` or the model's `Meta.ordering`), in addition to the existing case where `order_by()` has been called on the sequence.
- This silences Django 5.2's paginator `UnorderedObjectListWarning` for a common pattern: a `QuerySetSequence` assembled from sub-`QuerySets` that are individually ordered and often sliced (Django 4+ forbids reordering a sliced `QuerySet`, so `.order_by()` on the sequence is not an option there).
- An empty `QuerySetSequence` is treated as ordered (vacuously true).

## Details

The current implementation at `queryset_sequence/__init__.py`:

```python
@property
def ordered(self):
    return bool(self._order_by)
```

becomes:

```python
@property
def ordered(self):
    if bool(self._order_by):
        return True
    return all(qs.ordered for qs in self._querysets)
```

No iteration or query is triggered — the check delegates to each sub-`QuerySet`'s own cheap `ordered` property.

## Test plan

- [x] New `TestOrdered` class in `tests/test_querysetsequence.py` with 8 tests covering:
  - `order_by()` on the sequence -> `True`
  - All sub-QuerySets ordered via `order_by()` -> `True`
  - At least one sub-QuerySet unordered -> `False`
  - All sub-QuerySets unordered -> `False`
  - `Meta.ordering` on a sub-QuerySet model counts as ordered -> `True`
  - Mixed `Meta.ordering` + `order_by()` -> `True`
  - Empty `QuerySetSequence` -> `True`
  - Sequence-level `order_by()` wins over unordered sub-QuerySets -> `True`
- [x] Full suite (248 tests) passes against Django 4.2, 5.2, and 6.0.
- [x] Updated `docs/api.rst` with a new "Attributes" table entry for `ordered`.
- [x] Updated `CHANGELOG.rst`.